### PR TITLE
Add support for custom configuration of the underlying DynamoDBClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 This is a fork from [awslabs/emr-dynamodb-connector](https://github.com/awslabs/emr-dynamodb-connector), including features specific to [ScyllaDB Alternator](https://opensource.docs.scylladb.com/stable/alternator/alternator.html) and to the needs of the [ScyllaDB Migrator](https://migrator.docs.scylladb.com).
 
+## Changes compared to the original library
+
+- Add `DynamoDBConstants.CUSTOM_CLIENT_BUILDER_TRANSFORMER` that allows users to pass in the Hadoop job configuration the name of a class that implements `DynamoDbClientBuilderTransformer` to customize the underlying DynamoDB client.
+
+The complete changelog can be viewed here: [master...scylla-5.x](https://github.com/awslabs/emr-dynamodb-connector/compare/master...scylladb:emr-dynamodb-connector:scylla-5.x).
+
 ## Introduction
 You can use this connector to access data in Amazon DynamoDB using Apache Hadoop, Apache Hive, and
 Apache Spark in Amazon EMR. You can process data directly in DynamoDB using these frameworks, or

--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -30,6 +30,7 @@ public interface DynamoDBConstants {
   String DEFAULT_ACCESS_KEY_CONF = "fs.s3.awsAccessKeyId";
   String DEFAULT_SECRET_KEY_CONF = "fs.s3.awsSecretAccessKey";
   String CUSTOM_CREDENTIALS_PROVIDER_CONF = "dynamodb.customAWSCredentialsProvider";
+  String CUSTOM_CLIENT_BUILDER_TRANSFORMER = "dynamodb.customClientBuilderTransformer";
 
   // Table constants
   String DYNAMODB_COLUMN_MAPPING = "dynamodb.column.mapping";

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDbClientBuilderTransformer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDbClientBuilderTransformer.java
@@ -1,0 +1,17 @@
+package org.apache.hadoop.dynamodb;
+
+import java.util.function.UnaryOperator;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+/**
+ * Transformer of a DynamoDbClientBuilder. Takes as a parameter the DynamoDbClientBuilder instance
+ * configured by emr-dynamodb-connector.
+ */
+@FunctionalInterface
+public interface DynamoDbClientBuilderTransformer extends UnaryOperator<DynamoDbClientBuilder> {
+
+  static DynamoDbClientBuilderTransformer identity() {
+    return builder -> builder;
+  }
+
+}

--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/emr-dynamodb-tools/pom.xml
+++ b/emr-dynamodb-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.scylladb.alternator</groupId>
     <artifactId>emr-dynamodb-connector</artifactId>
-    <version>5.5.0-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>EMRDynamoDBConnector</name>
     <description>EMR DynamoDB Connector</description>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/hive2-shims/pom.xml
+++ b/shims/hive2-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/hive3-shims/pom.xml
+++ b/shims/hive3-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Relates to scylladb/scylla-migrator#117

This change will allow us to seamlessly plug our `AlternatorEndpointProvider` (see https://github.com/scylladb/scylla-migrator/pull/185/commits/de3bf3ef8cbddf0b96858224474e0ed729d749bf).