### PR TITLE
Adopt the splitting strategy of the ScyllaDB Migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a fork from [awslabs/emr-dynamodb-connector](https://github.com/awslabs/
 ## Changes compared to the original library
 
 - Add `DynamoDBConstants.CUSTOM_CLIENT_BUILDER_TRANSFORMER` that allows users to pass in the Hadoop job configuration the name of a class that implements `DynamoDbClientBuilderTransformer` to customize the underlying DynamoDB client.
+- Change the strategy that splits Hadoop jobs into tasks (in class `DynamoDBInputFormat`) as follows:
+  - Break down the data into chunks of 100 MB instead of 1 GB;
+  - Set the number of task mappers to the number of scan segments by default;
+  - Do not constrain the number of task mappers based on the estimated memory of the worker nodes.
 
 The complete changelog can be viewed here: [master...scylla-5.x](https://github.com/awslabs/emr-dynamodb-connector/compare/master...scylladb:emr-dynamodb-connector:scylla-5.x).
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -100,7 +100,7 @@ public interface DynamoDBConstants {
   double BYTES_PER_READ_CAPACITY_UNIT = 4096;
   double BYTES_PER_WRITE_CAPACITY_UNIT = 1024;
 
-  long MAX_BYTES_PER_SEGMENT = 1024L * 1024L * 1024L;
+  long MAX_BYTES_PER_SEGMENT = 100 * 1024L * 1024L; // At most 100 MB per segment
   double MIN_IO_PER_SEGMENT = 100.0;
 
   int PSCAN_SEGMENT_BATCH_SIZE = 50;

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/DynamoDBInputFormatTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/DynamoDBInputFormatTest.java
@@ -1,0 +1,98 @@
+package org.apache.hadoop.dynamodb.read;
+
+import org.apache.hadoop.dynamodb.DynamoDBConstants;
+import org.apache.hadoop.dynamodb.split.DynamoDBSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class DynamoDBInputFormatTest {
+
+  @Test
+  public void testProvisionedTable() throws IOException {
+    JobConf conf = makeJobConf(
+        234 * 1024L * 1024L, // 234 MB
+        Optional.of(25), // 25 provisioned RCUs
+        Optional.empty() // No configured scan segments
+    );
+    checkSplits(conf, 2);
+  }
+
+  @Test
+  public void testProvisionedTableLowRCU() throws IOException {
+    JobConf conf = makeJobConf(
+        50 * 1024L * 1024L * 1024L, // 50 GB
+        Optional.of(1), // 1 provisioned RCU
+        Optional.empty() // No configured scan segments
+    );
+    checkSplits(conf, 20); // Number of partitions is low because of the table low RCUs
+  }
+
+  @Test
+  public void testConfiguredScanSegments() throws IOException {
+    JobConf conf = makeJobConf(
+        234 * 1024L * 1024L, // 234 MB
+        Optional.of(25), // 25 provisioned RCUs
+        Optional.of(5)   // Explicit configuration for total scan segments
+    );
+    checkSplits(conf, 5);
+  }
+
+  @Test
+  public void testOnDemandTable() throws IOException {
+    JobConf conf = makeJobConf(
+        234 * 1024L * 1024L, // 234 MB
+        Optional.empty(), // On-demand billing mode
+        Optional.empty()  // No configured scan segments
+    );
+    checkSplits(conf, 2);
+  }
+
+  private JobConf makeJobConf(
+      long tableSizeBytes,
+      Optional<Integer> provisionedReadCapacityUnits,
+      Optional<Integer> configuredScanSegments
+  ) {
+    JobConf conf = new JobConf();
+    // Set table size
+    conf.set(DynamoDBConstants.TABLE_SIZE_BYTES, Long.toString(tableSizeBytes));
+    // Set read throughput
+    provisionedReadCapacityUnits.ifPresent(rcu ->
+        conf.set(
+            DynamoDBConstants.READ_THROUGHPUT,
+            Long.toString((long)(rcu * DynamoDBConstants.BYTES_PER_READ_CAPACITY_UNIT))
+        )
+    );
+    if (!provisionedReadCapacityUnits.isPresent()) {
+      conf.set(
+          DynamoDBConstants.READ_THROUGHPUT,
+          Long.toString((long)(DynamoDBConstants.DEFAULT_CAPACITY_FOR_ON_DEMAND * DynamoDBConstants.BYTES_PER_READ_CAPACITY_UNIT))
+      );
+    }
+    // Scan segments
+    configuredScanSegments.ifPresent(scanSegments ->
+        conf.set(DynamoDBConstants.SCAN_SEGMENTS, scanSegments.toString())
+    );
+    return conf;
+  }
+
+  private void checkSplits(JobConf conf, int expectedSplitNumber) throws IOException {
+    DynamoDBInputFormat inputFormat = new DynamoDBInputFormat();
+    List<DynamoDBSplit> splits =
+        Arrays.stream(inputFormat.getSplits(conf, 1))
+            .map(split -> (DynamoDBSplit) split)
+            .collect(Collectors.toList());
+
+    assertEquals(expectedSplitNumber, splits.size());
+    // By default, each partition is assigned exactly one scan segment
+    splits.forEach(split -> assertEquals(1, split.getSegments().size()));
+  }
+
+}

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/read/HiveDynamoDBInputFormat.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/read/HiveDynamoDBInputFormat.java
@@ -98,13 +98,13 @@ public class HiveDynamoDBInputFormat extends DynamoDBInputFormat {
   }
 
   @Override
-  protected int getNumMappers(int configuredReadThroughput, JobConf conf)
+  protected int getNumMappers(int numSegments, int configuredReadThroughput, JobConf conf)
       throws IOException {
     if (isQuery(conf)) {
       log.info("Defaulting to 1 mapper because there are key conditions");
       return 1;
     } else {
-      return super.getNumMappers(configuredReadThroughput, conf);
+      return super.getNumMappers(numSegments, configuredReadThroughput, conf);
     }
   }
 


### PR DESCRIPTION
- Split data into tasks of 100 MB each instead of 1 GB each
- Remove the constraint on the number of task mappers based on the memory of the worker nodes
- Set the number of task mappers to the number of scan segments

Relates to scylladb/scylla-migrator#130

I forward-ported the splitting strategy implemented here: https://github.com/scylladb/scylla-migrator/pull/143

This allows further simplifications in https://github.com/scylladb/scylla-migrator/pull/183.