### PR TITLE
Split the input data into segments of 100 MB on average

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/AbstractDynamoDBInputFormat.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/AbstractDynamoDBInputFormat.java
@@ -101,7 +101,7 @@ public abstract class AbstractDynamoDBInputFormat<K, V> implements InputFormat<K
     }
 
     // Segments for size
-    int numSegmentsForSize = (int) (currentTableSizeBytes / DynamoDBConstants
+    int numSegmentsForSize = (int) Math.round((double)currentTableSizeBytes / DynamoDBConstants
         .MAX_BYTES_PER_SEGMENT);
     log.info("Would use " + numSegmentsForSize + " segments for size");
 


### PR DESCRIPTION
In scylladb/scylla-migrator, we used to create segments of _at most_ 100 MB.

See https://github.com/scylladb/scylla-migrator/blob/0b3039220ed10923b030e3e34840b4aec7b6beb1/migrator/src/main/scala/com/scylladb/migrator/alternator/DynamoDBInputFormat.scala#L60-L63

Here, we used to create segments of _at least_ 100 MB.

I think we should create segments of 100 MB on average. Ie, if the input is 120 MB, let’s have just one segment, but if it is 180 MB, let’s have two segments of 90 MB each.