### PR TITLE
Filter out expired items when reading a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a fork from [awslabs/emr-dynamodb-connector](https://github.com/awslabs/
 ## Changes compared to the original library
 
 - Add `DynamoDBConstants.CUSTOM_CLIENT_BUILDER_TRANSFORMER` that allows users to pass in the Hadoop job configuration the name of a class that implements `DynamoDbClientBuilderTransformer` to customize the underlying DynamoDB client.
+- Automatically filter out expired items of tables where TTL is enabled. To use it, set `DynamoDBConstants.TTL_ATTRIBUTE_NAME` in the job configuration to the TTL attribute name of the table.
 - Change the strategy that splits Hadoop jobs into tasks (in class `DynamoDBInputFormat`) as follows:
   - Break down the data into chunks of 100 MB instead of 1 GB;
   - Set the number of task mappers to the number of scan segments by default;

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -56,6 +56,7 @@ public interface DynamoDBConstants {
   String TABLE_NAME = "dynamodb.table.name";
   String OUTPUT_TABLE_NAME = "dynamodb.output.tableName";
   String INPUT_TABLE_NAME = "dynamodb.input.tableName";
+  String TTL_ATTRIBUTE_NAME = "dynamodb.input.ttlAttributeName";
 
   String THROUGHPUT_WRITE_PERCENT = "dynamodb.throughput.write.percent";
   String THROUGHPUT_READ_PERCENT = "dynamodb.throughput.read.percent";

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
@@ -1,6 +1,6 @@
 package org.apache.hadoop.dynamodb.preader;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -8,6 +8,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.dynamodb.DynamoDBClient;
+import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
 import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
@@ -22,7 +23,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
@@ -50,6 +54,32 @@ public final class ScanRecordReadRequestTest {
     PageResults<Map<String, AttributeValue>> pageResults =
         readRequest.fetchPage(new RequestLimit(0, 0));
     assertEquals(0.0, pageResults.consumedRcu, 0.0);
+  }
+
+  @Test
+  public void queryFilterIsEmptyWhenTtlAttributeNameIsEmpty() {
+    when(context.getClient()).thenReturn(client);
+    when(context.getConf()).thenReturn(new JobConf());
+    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit());
+    ScanReadManager readManager = Mockito.mock(ScanReadManager.class);
+    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, null);
+    assertFalse(readRequest.queryFilter().isPresent());
+  }
+
+  @Test
+  public void queryFilterIsDefinedWhenTtlAttributeNameIsDefined() {
+    final String ttlAttributeName = "foo";
+    when(context.getClient()).thenReturn(client);
+    JobConf conf = new JobConf();
+    conf.set(DynamoDBConstants.TTL_ATTRIBUTE_NAME, ttlAttributeName);
+    when(context.getConf()).thenReturn(conf);
+    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit());
+    ScanReadManager readManager = Mockito.mock(ScanReadManager.class);
+    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, null);
+    Optional<DynamoDBQueryFilter> maybeQueryFilter = readRequest.queryFilter();
+    assertTrue(maybeQueryFilter.isPresent());
+    Map<String, Condition> scanFilter = maybeQueryFilter.get().getScanFilter();
+    assertNotNull(scanFilter.get(ttlAttributeName));
   }
 
   private void stubScanTableWith(RetryResult<ScanResponse> scanResultRetryResult) {


### PR DESCRIPTION
Add a new configuration key, `DynamoDBConstants.TTL_ATTRIBUTE_NAME`, which can be set to the TTL attribute name of a table to read. When this key is defined, we automatically filter out the expired items from the table.

Relates to https://github.com/scylladb/scylla-migrator/issues/179.