### PR TITLE
Evaluate the Scan Filter to add once per partition

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
@@ -13,38 +13,45 @@
 
 package org.apache.hadoop.dynamodb.preader;
 
-import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
-import org.apache.hadoop.dynamodb.filter.DynamoDBFilter;
-import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
 import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
-import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 public class ScanRecordReadRequest extends AbstractRecordReadRequest {
 
+  /** Optional ScanFilter to add to Scan requests */
+  final Optional<DynamoDBQueryFilter> maybeScanFilter;
+
+  @Deprecated
   public ScanRecordReadRequest(AbstractReadManager readMgr, DynamoDBRecordReaderContext context,
       int segment, Map<String, AttributeValue> lastEvaluatedKey) {
     super(readMgr, context, segment, lastEvaluatedKey);
+    this.maybeScanFilter = Optional.empty();
+  }
+
+  public ScanRecordReadRequest(AbstractReadManager readMgr, DynamoDBRecordReaderContext context,
+      int segment, Optional<DynamoDBQueryFilter> maybeScanFilter,
+      Map<String, AttributeValue> lastEvaluatedKey) {
+    super(readMgr, context, segment, lastEvaluatedKey);
+    this.maybeScanFilter = maybeScanFilter;
   }
 
   @Override
   protected AbstractRecordReadRequest buildNextReadRequest(PageResults<Map<String,
       AttributeValue>> pageResults) {
-    return new ScanRecordReadRequest(readMgr, context, segment, pageResults.lastEvaluatedKey);
+    return new ScanRecordReadRequest(readMgr, context, segment, maybeScanFilter,
+        pageResults.lastEvaluatedKey);
   }
 
   @Override
   protected PageResults<Map<String, AttributeValue>> fetchPage(RequestLimit lim) {
     // Read from DynamoDB
     RetryResult<ScanResponse> retryResult = context.getClient()
-            .scanTable(tableName, queryFilter().orElse(null), segment,
+            .scanTable(tableName, maybeScanFilter.orElse(null), segment,
                 context.getSplit().getTotalSegments(), lastEvaluatedKey, lim.items,
                 context.getReporter());
 
@@ -62,45 +69,6 @@ public class ScanRecordReadRequest extends AbstractRecordReadRequest {
         response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null,
         consumedCapacityUnits,
         retries);
-  }
-
-  /**
-   * Set a Scan query filter to skip expired records if the configuration
-   * provides the TTL attribute name
-   */
-  Optional<DynamoDBQueryFilter> queryFilter() {
-    Optional<String> maybeTtlAttribute =
-        Optional.ofNullable(context.getConf().get(DynamoDBConstants.TTL_ATTRIBUTE_NAME));
-    return maybeTtlAttribute.map(attributeName -> {
-      long now = Instant.now().getEpochSecond();
-      DynamoDBQueryFilter filter = new DynamoDBQueryFilter();
-      filter.addScanFilter(new DynamoDBFilter() {
-        @Override
-        public String getColumnName() {
-          return attributeName;
-        }
-
-        @Override
-        public String getColumnType() {
-          throw new Error();
-        }
-
-        @Override
-        public DynamoDBFilterOperator getOperator() {
-          throw new Error();
-        }
-
-        @Override
-        public Condition getDynamoDBCondition() {
-          return Condition
-              .builder()
-              .comparisonOperator(ComparisonOperator.GT)
-              .attributeValueList(AttributeValue.fromN(String.valueOf(now)))
-              .build();
-        }
-      });
-      return filter;
-    });
   }
 
 }

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanReadManagerTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanReadManagerTest.java
@@ -1,0 +1,49 @@
+package org.apache.hadoop.dynamodb.preader;
+
+import org.apache.hadoop.dynamodb.DynamoDBConstants;
+import org.apache.hadoop.dynamodb.split.DynamoDBSegmentsSplit;
+import org.apache.hadoop.dynamodb.util.MockTimeSource;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class ScanReadManagerTest {
+
+  @Mock
+  DynamoDBRecordReaderContext context;
+
+  @Test
+  public void queryFilterIsEmptyWhenTtlAttributeNameIsEmpty() {
+    when(context.getConf()).thenReturn(new JobConf());
+    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit(null, 1, 1, Collections.singletonList(1), 1, 0, null));
+    ScanReadManager readManager = new ScanReadManager(Mockito.mock(RateController.class), new MockTimeSource(), context);
+    ScanRecordReadRequest readRequest = (ScanRecordReadRequest) readManager.dequeueReadRequest();
+    assertFalse(readRequest.maybeScanFilter.isPresent());
+  }
+
+  @Test
+  public void queryFilterIsDefinedWhenTtlAttributeNameIsDefined() {
+    final String ttlAttributeName = "foo";
+    JobConf conf = new JobConf();
+    conf.set(DynamoDBConstants.TTL_ATTRIBUTE_NAME, ttlAttributeName);
+    when(context.getConf()).thenReturn(conf);
+    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit(null, 1, 1, Collections.singletonList(1), 1, 0, null));
+    ScanReadManager readManager = new ScanReadManager(Mockito.mock(RateController.class), new MockTimeSource(), context);
+    ScanRecordReadRequest readRequest = (ScanRecordReadRequest) readManager.dequeueReadRequest();
+    assertTrue(readRequest.maybeScanFilter.isPresent());
+    Map<String, Condition> scanFilter = readRequest.maybeScanFilter.get().getScanFilter();
+    assertNotNull(scanFilter.get(ttlAttributeName));
+  }
+
+}

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.apache.hadoop.dynamodb.DynamoDBClient;
-import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
 import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
@@ -26,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
@@ -50,36 +48,10 @@ public final class ScanRecordReadRequestTest {
     when(context.getConf()).thenReturn(new JobConf());
     when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit());
     ScanReadManager readManager = Mockito.mock(ScanReadManager.class);
-    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, null);
+    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, Optional.empty(), null);
     PageResults<Map<String, AttributeValue>> pageResults =
         readRequest.fetchPage(new RequestLimit(0, 0));
     assertEquals(0.0, pageResults.consumedRcu, 0.0);
-  }
-
-  @Test
-  public void queryFilterIsEmptyWhenTtlAttributeNameIsEmpty() {
-    when(context.getClient()).thenReturn(client);
-    when(context.getConf()).thenReturn(new JobConf());
-    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit());
-    ScanReadManager readManager = Mockito.mock(ScanReadManager.class);
-    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, null);
-    assertFalse(readRequest.queryFilter().isPresent());
-  }
-
-  @Test
-  public void queryFilterIsDefinedWhenTtlAttributeNameIsDefined() {
-    final String ttlAttributeName = "foo";
-    when(context.getClient()).thenReturn(client);
-    JobConf conf = new JobConf();
-    conf.set(DynamoDBConstants.TTL_ATTRIBUTE_NAME, ttlAttributeName);
-    when(context.getConf()).thenReturn(conf);
-    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit());
-    ScanReadManager readManager = Mockito.mock(ScanReadManager.class);
-    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, null);
-    Optional<DynamoDBQueryFilter> maybeQueryFilter = readRequest.queryFilter();
-    assertTrue(maybeQueryFilter.isPresent());
-    Map<String, Condition> scanFilter = maybeQueryFilter.get().getScanFilter();
-    assertNotNull(scanFilter.get(ttlAttributeName));
   }
 
   private void stubScanTableWith(RetryResult<ScanResponse> scanResultRetryResult) {


### PR DESCRIPTION
Instead of computing the Scan Filter to add to the queries once per page to fetch, we compute it once per partition.

Follow-up on #10 