### PR TITLE
Read the AWS session token from the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a fork from [awslabs/emr-dynamodb-connector](https://github.com/awslabs/
   - Set the number of task mappers to the number of scan segments by default;
   - Do not constrain the number of task mappers based on the estimated memory of the worker nodes.
 - Add support for excluding a set of Scan segments.
+- Load the AWS session token from the credentials provided by Spark.
 
 The complete changelog can be viewed here: [master...scylla-5.x](https://github.com/awslabs/emr-dynamodb-connector/compare/master...scylladb:emr-dynamodb-connector:scylla-5.x).
 

--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -99,7 +99,8 @@ public class DynamoDBClient {
   private static final CredentialPairName DEFAULT_CREDENTIAL_PAIR_NAME =
       new CredentialPairName(
           DynamoDBConstants.DEFAULT_ACCESS_KEY_CONF,
-          DynamoDBConstants.DEFAULT_SECRET_KEY_CONF
+          DynamoDBConstants.DEFAULT_SECRET_KEY_CONF,
+          DynamoDBConstants.DEFAULT_SESSION_TOKEN_CONF
       );
   private final Map<String, List<WriteRequest>> writeBatchMap = new HashMap<>();
   private final DynamoDbClient dynamoDB;
@@ -472,7 +473,7 @@ public class DynamoDBClient {
     if (Strings.isNullOrEmpty(accessKey)) {
       accessKey = conf.get(DEFAULT_CREDENTIAL_PAIR_NAME.getAccessKeyName());
       secretKey = conf.get(DEFAULT_CREDENTIAL_PAIR_NAME.getSecretKeyName());
-      sessionKey = null;
+      sessionKey = conf.get(DEFAULT_CREDENTIAL_PAIR_NAME.getSessionKeyName());
     } else {
       secretKey = conf.get(DYNAMODB_SESSION_CREDENTIAL_PAIR_NAME.getSecretKeyName());
       sessionKey = conf.get(DYNAMODB_SESSION_CREDENTIAL_PAIR_NAME.getSessionKeyName());

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -27,8 +27,9 @@ public interface DynamoDBConstants {
   String DYNAMODB_ACCESS_KEY_CONF = "dynamodb.awsAccessKeyId";
   String DYNAMODB_SECRET_KEY_CONF = "dynamodb.awsSecretAccessKey";
   String DYNAMODB_SESSION_TOKEN_CONF = "dynamodb.awsSessionToken";
-  String DEFAULT_ACCESS_KEY_CONF = "fs.s3.awsAccessKeyId";
-  String DEFAULT_SECRET_KEY_CONF = "fs.s3.awsSecretAccessKey";
+  String DEFAULT_ACCESS_KEY_CONF = "fs.s3a.access.key";
+  String DEFAULT_SECRET_KEY_CONF = "fs.s3a.secret.key";
+  String DEFAULT_SESSION_TOKEN_CONF = "fs.s3a.session.token";
   String CUSTOM_CREDENTIALS_PROVIDER_CONF = "dynamodb.customAWSCredentialsProvider";
   String CUSTOM_CLIENT_BUILDER_TRANSFORMER = "dynamodb.customClientBuilderTransformer";
 

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBClientTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBClientTest.java
@@ -104,6 +104,24 @@ public class DynamoDBClientTest {
   }
 
   @Test
+  public void testDefaultCredentialsWithSessionToken() {
+    final String DEFAULT_ACCESS_KEY = "abc";
+    final String DEFAULT_SECRET_KEY = "xyz";
+    final String DEFAULT_SESSION_TOKEN = "007";
+    Configuration conf = new Configuration();
+    conf.set(DynamoDBConstants.DEFAULT_ACCESS_KEY_CONF, DEFAULT_ACCESS_KEY);
+    conf.set(DynamoDBConstants.DEFAULT_SECRET_KEY_CONF, DEFAULT_SECRET_KEY);
+    conf.set(DynamoDBConstants.DEFAULT_SESSION_TOKEN_CONF, DEFAULT_SESSION_TOKEN);
+
+    DynamoDBClient dynamoDBClient = new DynamoDBClient();
+    AwsCredentialsProvider provider = dynamoDBClient.getAwsCredentialsProvider(conf);
+    AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) provider.resolveCredentials();
+    Assert.assertEquals(DEFAULT_ACCESS_KEY, sessionCredentials.accessKeyId());
+    Assert.assertEquals(DEFAULT_SECRET_KEY, sessionCredentials.secretAccessKey());
+    Assert.assertEquals(DEFAULT_SESSION_TOKEN, sessionCredentials.sessionToken());
+  }
+
+  @Test
   public void testCustomCredentialsProviderWithConstructor() {
     final String MY_ACCESS_KEY = "abc";
     final String MY_SECRET_KEY = "xyz";

--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/emr-dynamodb-tools/pom.xml
+++ b/emr-dynamodb-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.scylladb.alternator</groupId>
     <artifactId>emr-dynamodb-connector</artifactId>
-    <version>5.7.2-SNAPSHOT</version>
+    <version>5.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>EMRDynamoDBConnector</name>
     <description>EMR DynamoDB Connector</description>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/hive2-shims/pom.xml
+++ b/shims/hive2-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/hive3-shims/pom.xml
+++ b/shims/hive3-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>shims</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.scylladb.alternator</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>5.7.2-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
- Change the configuration properties used to read the AWS credentials to match those supplied by Spark (see [here](https://github.com/apache/spark/blame/v3.0.0/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala))
- Also read the session token from this configuration properties