### PR TITLE
Log skipped line count due to TTL

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -178,28 +178,6 @@ public class DynamoDBClient {
       log.debug("Executing DynamoDB scan: " + scanRequest);
       return dynamoDB.scan(scanRequest);
     }, reporter, PrintCounter.DynamoDBReadThrottle);
-    String maybeTtlAttributeName = config.get(DynamoDBConstants.TTL_ATTRIBUTE_NAME);
-    // for information only
-    if (maybeTtlAttributeName != null &&  !maybeTtlAttributeName.isEmpty()) {
-      log.debug(
-          String.format(
-            "Reading table %s, taking %s into account for row TTL",
-            tableName,
-            maybeTtlAttributeName
-          )
-      );
-      if (!retryResult.result.scannedCount().equals(retryResult.result.count())
-              && log.isDebugEnabled()) {
-        log.debug(
-                String.format("Reading table %s with TTL field %s, %s rows were scanned "
-                                + "but only %s rows will be returned.",
-                        maybeTtlAttributeName,
-                        retryResult.result.scannedCount(),
-                        retryResult.result.count()
-                )
-        );
-      }
-    }
     return retryResult;
   }
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -188,8 +188,8 @@ public class DynamoDBClient {
             maybeTtlAttributeName
           )
       );
-      if (!retryResult.result.scannedCount().equals(retryResult.result.count())) {
-        log.warn(
+      if (!retryResult.result.scannedCount().equals(retryResult.result.count()) && log.isDebugEnabled()) {
+        log.debug(
                 String.format("Reading table %s with TTL field %s, %s rows were scanned "
                                 + "but only %s rows will be returned.",
                         maybeTtlAttributeName,

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -178,6 +178,27 @@ public class DynamoDBClient {
       log.debug("Executing DynamoDB scan: " + scanRequest);
       return dynamoDB.scan(scanRequest);
     }, reporter, PrintCounter.DynamoDBReadThrottle);
+    String maybeTtlAttributeName = config.get(DynamoDBConstants.TTL_ATTRIBUTE_NAME);
+    // for information only
+    if (maybeTtlAttributeName != null &&  !maybeTtlAttributeName.isEmpty()) {
+      log.debug(
+          String.format(
+            "Reading table %s, taking %s into account for row TTL",
+            tableName,
+            maybeTtlAttributeName
+          )
+      );
+      if (!retryResult.result.scannedCount().equals(retryResult.result.count())) {
+        log.warn(
+                String.format("Reading table %s with TTL field %s, %s rows were scanned "
+                                + "but only %s rows will be returned.",
+                        maybeTtlAttributeName,
+                        retryResult.result.scannedCount(),
+                        retryResult.result.count()
+                )
+        );
+      }
+    }
     return retryResult;
   }
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -188,7 +188,8 @@ public class DynamoDBClient {
             maybeTtlAttributeName
           )
       );
-      if (!retryResult.result.scannedCount().equals(retryResult.result.count()) && log.isDebugEnabled()) {
+      if (!retryResult.result.scannedCount().equals(retryResult.result.count())
+              && log.isDebugEnabled()) {
         log.debug(
                 String.format("Reading table %s with TTL field %s, %s rows were scanned "
                                 + "but only %s rows will be returned.",

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResultMultiplexer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResultMultiplexer.java
@@ -34,6 +34,7 @@ public class PageResultMultiplexer<V> {
 
   private final int batchSize;
   private final int capacity;
+  private int skippedRowsCounter;
   private final BlockingQueue<PageResults<V>> pages;
   private final AtomicInteger pageCount = new AtomicInteger();
   private final Object removeItemLock = new Object();
@@ -47,6 +48,7 @@ public class PageResultMultiplexer<V> {
     this.capacity = capacity;
     this.pages = new LinkedBlockingQueue<>(capacity);
     this.pageIterator = pages.iterator();
+    this.skippedRowsCounter = 0;
   }
 
   public boolean addPageResults(PageResults<V> page) {
@@ -64,6 +66,7 @@ public class PageResultMultiplexer<V> {
     }
 
     pageCount.incrementAndGet();
+    skippedRowsCounter += page.skippedRowsCount;
     log.info("Added a page. Page count: " + pageCount.get());
 
     return true;
@@ -72,7 +75,7 @@ public class PageResultMultiplexer<V> {
   public V next() throws IOException {
     if (itemsReturned % 10000 == 0) {
       log.info("Pagemux stats: items=" + itemsReturned + ", pages=" + pageCount.get() + ", cap="
-          + capacity);
+          + capacity + ", skippedRows=" + this.skippedRowsCounter);
     }
 
     synchronized (removeItemLock) {

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResultMultiplexer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResultMultiplexer.java
@@ -34,7 +34,8 @@ public class PageResultMultiplexer<V> {
 
   private final int batchSize;
   private final int capacity;
-  private int skippedRowsCounter;
+  // number of skipped rows during a scan, because of reached TTL
+  private volatile long skippedRowsCounter;
   private final BlockingQueue<PageResults<V>> pages;
   private final AtomicInteger pageCount = new AtomicInteger();
   private final Object removeItemLock = new Object();
@@ -48,7 +49,7 @@ public class PageResultMultiplexer<V> {
     this.capacity = capacity;
     this.pages = new LinkedBlockingQueue<>(capacity);
     this.pageIterator = pages.iterator();
-    this.skippedRowsCounter = 0;
+    this.skippedRowsCounter = 0L; //skipped rows are counted on addPageResults during a scan
   }
 
   public boolean addPageResults(PageResults<V> page) {

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResults.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResults.java
@@ -24,11 +24,13 @@ public class PageResults<V> {
   public final V lastEvaluatedKey;
   public final double consumedRcu;
   public final int retries;
+  public final int skippedRowsCount;
   public final Exception exception;
 
   private volatile int pos;
 
-  public PageResults(List<V> items, V lastEvaluatedKey, double consumedRcu, int retries) {
+  public PageResults(List<V> items, V lastEvaluatedKey, double consumedRcu,
+                     int retries, int skippedRowsCount) {
     if (items == null) {
       throw new IllegalArgumentException("Items must not be null");
     }
@@ -37,10 +39,11 @@ public class PageResults<V> {
     this.consumedRcu = consumedRcu;
     this.retries = retries;
     this.exception = null;
+    this.skippedRowsCount = skippedRowsCount;
   }
 
   public PageResults(List<V> items, V lastEvaluatedKey) {
-    this(items, lastEvaluatedKey, 0.0, 0);
+    this(items, lastEvaluatedKey, 0.0, 0, 0);
   }
 
   public PageResults(Exception exception) {
@@ -52,6 +55,7 @@ public class PageResults<V> {
     this.consumedRcu = 0;
     this.retries = 0;
     this.exception = exception;
+    this.skippedRowsCount = 0;
   }
 
   public V next() {

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
@@ -48,7 +48,7 @@ public class QueryRecordReadRequest extends AbstractRecordReadRequest {
         response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null,
         response.consumedCapacity().capacityUnits(),
         retries,
-        0 // only for scan
+        0 // only for scan can have skip raws, due to TTL filtering
     );
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
@@ -47,6 +47,8 @@ public class QueryRecordReadRequest extends AbstractRecordReadRequest {
         // Translate the default value to NULL here, to keep this assumption in other classes.
         response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null,
         response.consumedCapacity().capacityUnits(),
-        retries);
+        retries,
+        0 // only for scan
+    );
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
@@ -68,7 +68,9 @@ public class ScanRecordReadRequest extends AbstractRecordReadRequest {
         // Translate the default value to NULL here, to keep this assumption in other classes.
         response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null,
         consumedCapacityUnits,
-        retries);
+            retries,
+            response.scannedCount() - response.count()
+    );
   }
 
 }


### PR DESCRIPTION
This PR logs on the spark worker when there is a difference between the number of rows of a scan and the number of rows returned due to the use of a TTL field.