### PR TITLE
add TTL attribute not present and invalid type of TTL value to the filter, as well as enhance the testcases accordingly

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -167,8 +167,35 @@ public class DynamoDBClient {
 
     if (dynamoDBQueryFilter != null) {
       Map<String, Condition> scanFilter = dynamoDBQueryFilter.getScanFilter();
-      if (!scanFilter.isEmpty()) {
+      String filterExpression = dynamoDBQueryFilter.getFilterExpression();
+      Map<String, String> expressionAttributeNames =
+          dynamoDBQueryFilter.getExpressionAttributeNames();
+      Map<String, AttributeValue> expressionAttributeValues =
+          dynamoDBQueryFilter.getExpressionAttributeValues();
+      boolean hasLegacyScanFilter = !scanFilter.isEmpty();
+      boolean hasExpressionState = filterExpression != null
+          || (expressionAttributeNames != null && !expressionAttributeNames.isEmpty())
+          || (expressionAttributeValues != null && !expressionAttributeValues.isEmpty());
+
+      if (hasLegacyScanFilter && hasExpressionState) {
+        throw new IllegalArgumentException(
+            "ScanFilter and FilterExpression cannot be used together in the same Scan request. "
+                + "scanFilter keys: " + scanFilter.keySet()
+                + ", filterExpression: " + filterExpression);
+      }
+
+      if (hasLegacyScanFilter) {
         scanRequestBuilder.scanFilter(scanFilter);
+      }
+
+      if (filterExpression != null) {
+        scanRequestBuilder.filterExpression(filterExpression);
+      }
+      if (expressionAttributeNames != null && !expressionAttributeNames.isEmpty()) {
+        scanRequestBuilder.expressionAttributeNames(expressionAttributeNames);
+      }
+      if (expressionAttributeValues != null && !expressionAttributeValues.isEmpty()) {
+        scanRequestBuilder.expressionAttributeValues(expressionAttributeValues);
       }
     }
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBQueryFilter.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBQueryFilter.java
@@ -15,12 +15,17 @@ package org.apache.hadoop.dynamodb.filter;
 
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public class DynamoDBQueryFilter {
 
   private final Map<String, Condition> keyConditions = new HashMap<>();
   private final Map<String, Condition> scanFilter = new HashMap<>();
+
+  private String filterExpression;
+  private Map<String, String> expressionAttributeNames = new HashMap<>();
+  private Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
 
   private DynamoDBIndexInfo index;
 
@@ -46,5 +51,29 @@ public class DynamoDBQueryFilter {
 
   public void addScanFilter(DynamoDBFilter filter) {
     this.scanFilter.put(filter.getColumnName(), filter.getDynamoDBCondition());
+  }
+
+  public String getFilterExpression() {
+    return filterExpression;
+  }
+
+  public void setFilterExpression(String filterExpression) {
+    this.filterExpression = filterExpression;
+  }
+
+  public Map<String, String> getExpressionAttributeNames() {
+    return expressionAttributeNames;
+  }
+
+  public void setExpressionAttributeNames(Map<String, String> expressionAttributeNames) {
+    this.expressionAttributeNames = expressionAttributeNames;
+  }
+
+  public Map<String, AttributeValue> getExpressionAttributeValues() {
+    return expressionAttributeValues;
+  }
+
+  public void setExpressionAttributeValues(Map<String, AttributeValue> expressionAttributeValues) {
+    this.expressionAttributeValues = expressionAttributeValues;
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanReadManager.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanReadManager.java
@@ -16,19 +16,20 @@ package org.apache.hadoop.dynamodb.preader;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
-import org.apache.hadoop.dynamodb.filter.DynamoDBFilter;
-import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
 import org.apache.hadoop.dynamodb.util.AbstractTimeSource;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
-import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public class ScanReadManager extends AbstractReadManager {
+
+  public static final String TTL_FILTER_EXPRESSION =
+      "attribute_not_exists(#ttl) OR NOT attribute_type(#ttl, :ttlType) OR #ttl > :now";
 
   public ScanReadManager(RateController rateController, AbstractTimeSource time,
       DynamoDBRecordReaderContext context) {
@@ -58,33 +59,21 @@ public class ScanReadManager extends AbstractReadManager {
     Optional<DynamoDBQueryFilter> maybeScanFilter =
         Optional.ofNullable(context.getConf().get(DynamoDBConstants.TTL_ATTRIBUTE_NAME))
             .map(attributeName -> {
-              long now = Instant.now().getEpochSecond();
               DynamoDBQueryFilter filter = new DynamoDBQueryFilter();
-              filter.addScanFilter(new DynamoDBFilter() {
-                @Override
-                public String getColumnName() {
-                  return attributeName;
-                }
 
-                @Override
-                public String getColumnType() {
-                  throw new Error();
-                }
+              filter.setFilterExpression(TTL_FILTER_EXPRESSION);
 
-                @Override
-                public DynamoDBFilterOperator getOperator() {
-                  throw new Error();
-                }
+              Map<String, String> expressionAttributeNames = new HashMap<>();
+              expressionAttributeNames.put("#ttl", attributeName);
+              filter.setExpressionAttributeNames(expressionAttributeNames);
 
-                @Override
-                public Condition getDynamoDBCondition() {
-                  return Condition
-                      .builder()
-                      .comparisonOperator(ComparisonOperator.GT)
-                      .attributeValueList(AttributeValue.fromN(String.valueOf(now)))
-                      .build();
-                }
-              });
+              Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
+              // attribute_type() expects a type code ("N", "S", "B", etc.) as an S-typed value
+              expressionAttributeValues.put(":ttlType", AttributeValue.fromS("N"));
+              long now = Instant.now().getEpochSecond();
+              expressionAttributeValues.put(":now", AttributeValue.fromN(String.valueOf(now)));
+              filter.setExpressionAttributeValues(expressionAttributeValues);
+
               return filter;
             });
 

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBClientTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBClientTest.java
@@ -21,23 +21,25 @@ import com.google.common.collect.ImmutableMap;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
+import org.apache.hadoop.dynamodb.preader.ScanReadManager;
+import org.apache.hadoop.mapred.Reporter;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Map;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -52,7 +54,11 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.Capacity;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
 public class DynamoDBClientTest {
@@ -73,6 +79,43 @@ public class DynamoDBClientTest {
   public void setup() {
     conf.clear();
     client = new DynamoDBClient(mockClient, conf);
+  }
+
+  @Test
+  public void testScanTableUsesFilterExpressionWhenPresent() {
+    Mockito.when(mockClient.scan(Mockito.any(ScanRequest.class)))
+        .thenReturn(ScanResponse.builder().build());
+
+    DynamoDBQueryFilter filter = new DynamoDBQueryFilter();
+    filter.setFilterExpression(ScanReadManager.TTL_FILTER_EXPRESSION);
+    filter.setExpressionAttributeNames(ImmutableMap.of("#ttl", "ttl"));
+    filter.setExpressionAttributeValues(ImmutableMap.of(
+        ":ttlType", AttributeValue.fromS("N"),
+        ":now", AttributeValue.fromN("123")));
+
+    client.scanTable("dummyTable", filter, 0, 1, null, 1, Reporter.NULL);
+
+    ArgumentCaptor<ScanRequest> requestCaptor = ArgumentCaptor.forClass(ScanRequest.class);
+    Mockito.verify(mockClient).scan(requestCaptor.capture());
+
+    ScanRequest request = requestCaptor.getValue();
+    Assert.assertEquals(ScanReadManager.TTL_FILTER_EXPRESSION, request.filterExpression());
+    Assert.assertEquals("ttl", request.expressionAttributeNames().get("#ttl"));
+    Assert.assertEquals("N", request.expressionAttributeValues().get(":ttlType").s());
+    Assert.assertEquals("123", request.expressionAttributeValues().get(":now").n());
+    Assert.assertTrue(request.scanFilter() == null || request.scanFilter().isEmpty());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testScanTableRejectsMixedLegacyAndExpressionFilters() {
+    DynamoDBQueryFilter filter = new DynamoDBQueryFilter();
+    filter.getScanFilter().put("ttl", Condition.builder()
+        .comparisonOperator(ComparisonOperator.NULL)
+        .build());
+    filter.setFilterExpression("attribute_not_exists(#ttl)");
+    filter.setExpressionAttributeNames(ImmutableMap.of("#ttl", "ttl"));
+
+    client.scanTable("dummyTable", filter, 0, 1, null, 1, Reporter.NULL);
   }
 
   @Test

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanReadManagerTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanReadManagerTest.java
@@ -9,7 +9,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 import java.util.Collections;
 import java.util.Map;
@@ -42,8 +41,11 @@ public final class ScanReadManagerTest {
     ScanReadManager readManager = new ScanReadManager(Mockito.mock(RateController.class), new MockTimeSource(), context);
     ScanRecordReadRequest readRequest = (ScanRecordReadRequest) readManager.dequeueReadRequest();
     assertTrue(readRequest.maybeScanFilter.isPresent());
-    Map<String, Condition> scanFilter = readRequest.maybeScanFilter.get().getScanFilter();
-    assertNotNull(scanFilter.get(ttlAttributeName));
+    org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter filter = readRequest.maybeScanFilter.get();
+    assertEquals(ScanReadManager.TTL_FILTER_EXPRESSION, filter.getFilterExpression());
+    assertEquals(ttlAttributeName, filter.getExpressionAttributeNames().get("#ttl"));
+    assertEquals("N", filter.getExpressionAttributeValues().get(":ttlType").s());
+    assertNotNull(filter.getExpressionAttributeValues().get(":now"));
   }
 
 }


### PR DESCRIPTION
This is to address the issue reported in https://github.com/scylladb/scylla-migrator/issues/233

The logic changes include the following:
1. add the case of TTL attribute not presenting to the filter
2. add the case of non-number(potentially malformed) values of TTL attribute to the filter for safety
3. reject mixed legacy scanFilter plus expression-based filtering in the same scan request
4. add the test cases accordingly